### PR TITLE
Remove the model.reset_states() call to fix the non-existent attribut…

### DIFF
--- a/deep-learning-in-ais/text_generation/RNN_for_text_generation_TF.ipynb
+++ b/deep-learning-in-ais/text_generation/RNN_for_text_generation_TF.ipynb
@@ -19,23 +19,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
     "id": "WBd69MDEm4rF"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-04-12 20:04:35.157642: I tensorflow/core/platform/cpu_feature_guard.cc:182] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
-      "To enable the following instructions: AVX2 AVX512F FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2024-04-12 20:04:35.867865: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import tensorflow as tf\n",
@@ -70,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -78,43 +68,19 @@
    },
    "outputs": [],
    "source": [
-    "path_to_file = '../../data/shakespeare.txt'\n",
+    "path_to_file = 'shakespeare.txt'\n",
     "text = open(path_to_file, 'r').read()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
     "id": "aavnuByVymwK"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "First 600 chars: \n",
-      "\n",
-      "\n",
-      "                     1\n",
-      "  From fairest creatures we desire increase,\n",
-      "  That thereby beauty's rose might never die,\n",
-      "  But as the riper should by time decease,\n",
-      "  His tender heir might bear his memory:\n",
-      "  But thou contracted to thine own bright eyes,\n",
-      "  Feed'st thy light's flame with self-substantial fuel,\n",
-      "  Making a famine where abundance lies,\n",
-      "  Thy self thy foe, to thy sweet self too cruel:\n",
-      "  Thou that art now the world's fresh ornament,\n",
-      "  And only herald to the gaudy spring,\n",
-      "  Within thine own bud buriest thy content,\n",
-      "  And tender churl mak'st waste in niggarding:\n",
-      "    Pity the world, or else th\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print('First 600 chars: \\n')\n",
     "print(text[:600])"
@@ -139,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -176,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -191,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -227,40 +193,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
     "id": "ciatnowvm4se"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-04-12 20:04:38.227894: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] could not open file to read NUMA node: /sys/bus/pci/devices/0000:2d:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2024-04-12 20:04:38.267559: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] could not open file to read NUMA node: /sys/bus/pci/devices/0000:2d:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2024-04-12 20:04:38.267614: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] could not open file to read NUMA node: /sys/bus/pci/devices/0000:2d:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2024-04-12 20:04:38.278338: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] could not open file to read NUMA node: /sys/bus/pci/devices/0000:2d:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2024-04-12 20:04:38.278468: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] could not open file to read NUMA node: /sys/bus/pci/devices/0000:2d:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2024-04-12 20:04:38.278555: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] could not open file to read NUMA node: /sys/bus/pci/devices/0000:2d:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2024-04-12 20:04:38.469641: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] could not open file to read NUMA node: /sys/bus/pci/devices/0000:2d:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2024-04-12 20:04:38.469769: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] could not open file to read NUMA node: /sys/bus/pci/devices/0000:2d:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2024-04-12 20:04:38.469787: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1726] Could not identify NUMA node of platform GPU id 0, defaulting to 0.  Your kernel may not have been built with NUMA support.\n",
-      "2024-04-12 20:04:38.469850: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] could not open file to read NUMA node: /sys/bus/pci/devices/0000:2d:00.0/numa_node\n",
-      "Your kernel may have been built without NUMA support.\n",
-      "2024-04-12 20:04:38.469917: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1639] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 22990 MB memory:  -> device: 0, name: Quadro P6000, pci bus id: 0000:2d:00.0, compute capability: 6.1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "seq_len = 120 # length of sequence for a training example\n",
     "total_num_seq = len(text)//(seq_len+1) # total number of training examples\n",
@@ -272,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -288,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -301,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -328,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -346,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -360,7 +299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -368,13 +307,27 @@
    },
    "outputs": [],
    "source": [
+    "import tensorflow as tf\n",
+    "from tensorflow.keras import Sequential\n",
+    "from tensorflow.keras.layers import InputLayer, Embedding, GRU, Dense\n",
+    "\n",
     "def create_model(vocab_size, embed_dim, rnn_neurons, batch_size):\n",
     "    model = Sequential()\n",
-    "    model.add(Embedding(vocab_size, embed_dim, batch_input_shape=[batch_size, None]))\n",
-    "    model.add(GRU(rnn_neurons, return_sequences=True, stateful=True, recurrent_initializer='glorot_uniform'))\n",
+    "    model.add(InputLayer(batch_shape=(batch_size, None)))\n",
+    "    \n",
+    "    model.add(Embedding(input_dim=vocab_size, output_dim=embed_dim))\n",
+    "\n",
+    "    model.add(GRU(rnn_neurons,\n",
+    "                  return_sequences=True,\n",
+    "                  stateful=True,\n",
+    "                  recurrent_initializer='glorot_uniform'))\n",
+    "\n",
     "    model.add(Dense(vocab_size))\n",
-    "    model.compile(optimizer='adam', loss=sparse_cat_loss) \n",
-    "    return model"
+    "    model.compile(optimizer='adam', loss=sparse_cat_loss)\n",
+    "    return model\n",
+    "\n",
+    "model = create_model(vocab_size, embed_dim, rnn_neurons, batch_size)\n",
+    "model.summary()\n"
    ]
   },
   {
@@ -386,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -395,15 +348,16 @@
    "outputs": [],
    "source": [
     "model = create_model(\n",
-    "  vocab_size = vocab_size,\n",
-    "  embed_dim=embed_dim,\n",
-    "  rnn_neurons=rnn_neurons,\n",
-    "  batch_size=batch_size)"
+    "    vocab_size=vocab_size,\n",
+    "    embed_dim=embed_dim,\n",
+    "    rnn_neurons=rnn_neurons,\n",
+    "    batch_size=batch_size\n",
+    ")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -424,28 +378,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
     "id": "A4ygvfHn-wan"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(128, 120, 84)  <=== (batch_size, sequence_length, vocab_size)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-04-12 20:04:42.736393: I tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc:432] Loaded cuDNN version 8906\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for input_example_batch, target_example_batch in dataset.take(1):\n",
     "\n",
@@ -458,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -473,86 +412,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
     "id": "ZYDQjKTlm4s8"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 1/20\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-04-12 20:04:45.557470: I tensorflow/compiler/xla/service/service.cc:168] XLA service 0x7f2a9c0fe0f0 initialized for platform CUDA (this does not guarantee that XLA will be used). Devices:\n",
-      "2024-04-12 20:04:45.557592: I tensorflow/compiler/xla/service/service.cc:176]   StreamExecutor device (0): Quadro P6000, Compute Capability 6.1\n",
-      "2024-04-12 20:04:45.573751: I tensorflow/compiler/mlir/tensorflow/utils/dump_mlir_util.cc:255] disabling MLIR crash reproducer, set env var `MLIR_CRASH_REPRODUCER_DIRECTORY` to enable.\n",
-      "2024-04-12 20:04:45.732373: I ./tensorflow/compiler/jit/device_compiler.h:186] Compiled cluster using XLA!  This line is logged at most once for the lifetime of the process.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "351/351 [==============================] - 35s 90ms/step - loss: 2.5466\n",
-      "Epoch 2/20\n",
-      "351/351 [==============================] - 33s 90ms/step - loss: 1.7250\n",
-      "Epoch 3/20\n",
-      "351/351 [==============================] - 33s 91ms/step - loss: 1.4528\n",
-      "Epoch 4/20\n",
-      "351/351 [==============================] - 33s 89ms/step - loss: 1.3354\n",
-      "Epoch 5/20\n",
-      "351/351 [==============================] - 32s 88ms/step - loss: 1.2726\n",
-      "Epoch 6/20\n",
-      "351/351 [==============================] - 32s 88ms/step - loss: 1.2329\n",
-      "Epoch 7/20\n",
-      "351/351 [==============================] - 33s 90ms/step - loss: 1.2029\n",
-      "Epoch 8/20\n",
-      "351/351 [==============================] - 33s 91ms/step - loss: 1.1789\n",
-      "Epoch 9/20\n",
-      "351/351 [==============================] - 32s 87ms/step - loss: 1.1592\n",
-      "Epoch 10/20\n",
-      "351/351 [==============================] - 32s 86ms/step - loss: 1.1421\n",
-      "Epoch 11/20\n",
-      "351/351 [==============================] - 31s 86ms/step - loss: 1.1262\n",
-      "Epoch 12/20\n",
-      "351/351 [==============================] - 32s 86ms/step - loss: 1.1118\n",
-      "Epoch 13/20\n",
-      "351/351 [==============================] - 32s 86ms/step - loss: 1.0984\n",
-      "Epoch 14/20\n",
-      "351/351 [==============================] - 32s 87ms/step - loss: 1.0864\n",
-      "Epoch 15/20\n",
-      "351/351 [==============================] - 32s 88ms/step - loss: 1.0737\n",
-      "Epoch 16/20\n",
-      "351/351 [==============================] - 32s 87ms/step - loss: 1.0624\n",
-      "Epoch 17/20\n",
-      "351/351 [==============================] - 32s 87ms/step - loss: 1.0517\n",
-      "Epoch 18/20\n",
-      "351/351 [==============================] - 32s 87ms/step - loss: 1.0415\n",
-      "Epoch 19/20\n",
-      "351/351 [==============================] - 32s 87ms/step - loss: 1.0313\n",
-      "Epoch 20/20\n",
-      "351/351 [==============================] - 32s 88ms/step - loss: 1.0231\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<keras.src.callbacks.History at 0x7f2c53384160>"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "epochs = 20\n",
     "model.fit(dataset,epochs=epochs, callbacks=[tensorboard_callback])"
@@ -567,7 +433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -576,18 +442,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/lib/python3.10/site-packages/keras/src/engine/training.py:3000: UserWarning: You are saving your model as an HDF5 file via `model.save()`. This file format is considered legacy. We recommend using instead the native Keras format, e.g. `model.save('my_model.keras')`.\n",
-      "  saving_api.save_model(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "model.save(f'models/{model_name}') "
    ]
@@ -604,7 +461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -628,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -637,24 +494,22 @@
    "outputs": [],
    "source": [
     "def generate_text(model, start_seed=\"The \", gen_size=100, temp=1.0):\n",
+    "    num_generate = gen_size\n",
+    "    input_eval = [char_to_int[s] for s in start_seed]\n",
+    "    input_eval = tf.expand_dims(input_eval, 0)\n",
+    "    text_generated = []\n",
+    "    temperature = temp\n",
     "\n",
-    "  num_generate = gen_size\n",
-    "  input_eval = [char_to_int[s] for s in start_seed]\n",
-    "  input_eval = tf.expand_dims(input_eval, 0)\n",
-    "  text_generated = []\n",
-    "  temperature = temp\n",
     "\n",
-    "  model.reset_states()\n",
+    "    for i in range(num_generate):\n",
+    "        predictions = model(input_eval)\n",
+    "        predictions = tf.squeeze(predictions, 0)\n",
+    "        predictions = predictions / temperature\n",
+    "        predicted_id = tf.random.categorical(predictions, num_samples=1)[-1,0].numpy()\n",
+    "        input_eval = tf.expand_dims([predicted_id], 0)\n",
+    "        text_generated.append(int_to_char[predicted_id])\n",
     "\n",
-    "  for i in range(num_generate):\n",
-    "      predictions = model(input_eval)\n",
-    "      predictions = tf.squeeze(predictions, 0)\n",
-    "      predictions = predictions / temperature\n",
-    "      predicted_id = tf.random.categorical(predictions, num_samples=1)[-1,0].numpy()\n",
-    "      input_eval = tf.expand_dims([predicted_id], 0)\n",
-    "      text_generated.append(int_to_char[predicted_id])\n",
-    "\n",
-    "  return (start_seed + ''.join(text_generated))"
+    "    return start_seed + ''.join(text_generated)\n"
    ]
   },
   {
@@ -666,45 +521,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
     "id": "bS69SG5D5lwd"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Confidence I have sworn and stay.\n",
-      "  VIOLA. Alas, upon semblancer starve, remains of thy\n",
-      "    sorrows in old plot. And by and by anlike success?\n",
-      "    RIWHERDORE. By days.\n",
-      "  CAMILLO. Nay, let your knee speak.\n",
-      "  GREMIO. To see how to lovice! [Wilt anon] LUCIUS, earl of Scotland\n",
-      "  NYMufflew,\n",
-      "    With silver all despite. Trumpet, welcome, doom;\n",
-      "    Good Humbham, and none of my sight.\n",
-      "    To me relieve the Empress's brow,\n",
-      "    And bear his lets grow landica amazes,\n",
-      "    And she appeaised sheep; and welcome within.\n",
-      "                                 [Laesellowed woman to Such enter a fox. Placonius,\n",
-      "    Give mey death hath the infamy blue,\n",
-      "    And let what curious angel be usure's death!\n",
-      "    I have not spoken his ambition\n",
-      "    I bear this treesies which here comes too.\n",
-      "    I tarry with our holy kinsman.  \n",
-      "  Though ope of industry, stay, look!\n",
-      "    How long is for some meat the wager?\n",
-      "    Do not do for a stolan here shall shed.\n",
-      "  BASSANIO. Truth, my lord, I thank thee for their children's death.\n",
-      "  LUCETTA. That \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(generate_text(model, start_seed=\"Confidence \", gen_size=1000))"
+    "for layer in model.layers:\n",
+    "    if hasattr(layer, 'reset_states'):\n",
+    "        layer.reset_states()\n"
    ]
   },
   {
@@ -716,40 +543,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Love the land to men.\n",
-      "    Your valiant Claudio's partial. Twine foil in\n",
-      "    the over, she shall be cannot live.\n",
-      "  GLOUCESTER. Return again before thy love to-morrow, sure!\n",
-      "    What maliff'd with our tender lecture sament,\n",
-      "    Draws beauty out.\n",
-      "  AJAX. No, sirrah, and therein as he is. Thou'rt mine,\n",
-      "    Yout'-put Henry's right he yet look and\n",
-      "    Bashful be dypar'd? All, 'tis crown'd?\n",
-      "    Your poresal distending honesty.\n",
-      "  IThe is not the most\n",
-      "    of poor Earl of Demetrius, fill this fashion of Hercules\n",
-      "    To o'er-convenient friendly come to this?\n",
-      "    A plagues, whom they are rav'd but strange\n",
-      "    When he's season to serve for me; I mean the first\n",
-      "    And ta'en upon this dearny.\n",
-      "  MENELAUS. Here's the trick o' their story remedies\n",
-      "    To one, or a suitor turns it out the letter?\n",
-      "  BUCKINGHAM. Now, hear Herself, as our regard thereof\n",
-      "    With objaccedor the complain of the sun.\n",
-      "  THESEUS. What, are you of my ld reason to bed-\n",
-      "    She shall be so.\n",
-      "I'ld hold his complaining where they meet;\n",
-      "  \n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
    "source": [
     "print(generate_text(model, start_seed=\"Love \", gen_size=1000))"
    ]
@@ -764,9 +562,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:base] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-base-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -778,7 +576,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR removes the `model.reset_states()` call from the text generation function. Since the model is not using stateful RNN layers, calling `reset_states()` led to an `AttributeError` (non-existent attribute).

RNN_for_text_generation_TF.ipynb