### PR TITLE
Fix requirements.txt on OpenCellID

### DIFF
--- a/ngc-integration/OpenCellID/Exploration-Pandas.ipynb
+++ b/ngc-integration/OpenCellID/Exploration-Pandas.ipynb
@@ -49,7 +49,7 @@
    "outputs": [],
    "source": [
     "# Install required packages\n",
-    "! pip install hvplot pydeck panel"
+    "!pip install -r requirements.txt --upgrade --no-deps --quiet\n"
    ]
   },
   {

--- a/ngc-integration/OpenCellID/requirements.txt
+++ b/ngc-integration/OpenCellID/requirements.txt
@@ -1,3 +1,3 @@
-hvplot 
-pydeck
-panel
+panel==1.3.8
+pydeck==0.8.0
+hvplot==0.9.2


### PR DESCRIPTION
This PR pins the versions of the `panel`, `pydeck`, and `hvplot` packages in the `requirements.txt` file to avoid compatibility issues such as the following error:

This error was caused by recent changes in the `pydeck` API that are not compatible with the current version of `panel`.

---

What was done

- Fixed versions for the following packages:
  - `panel==1.3.8`
  - `pydeck==0.8.0`
  - `hvplot==0.9.2`
- Added a script in the notebook to install packages from `requirements.txt`.

---