### PR TITLE
Fix: Opencell requirements

### DIFF
--- a/ngc-integration/OpenCellID/Exploration-Pandas.ipynb
+++ b/ngc-integration/OpenCellID/Exploration-Pandas.ipynb
@@ -49,7 +49,7 @@
    "outputs": [],
    "source": [
     "# Install required packages\n",
-    "!pip install -r requirements.txt --upgrade --no-deps --quiet"
+    "!pip install -r requirements.txt --quiet"
    ]
   },
   {

--- a/ngc-integration/OpenCellID/Exploration-Pandas.ipynb
+++ b/ngc-integration/OpenCellID/Exploration-Pandas.ipynb
@@ -49,7 +49,7 @@
    "outputs": [],
    "source": [
     "# Install required packages\n",
-    "! pip install hvplot pydeck panel"
+    "!pip install -r requirements.txt --upgrade --no-deps --quiet"
    ]
   },
   {

--- a/ngc-integration/OpenCellID/requirements.txt
+++ b/ngc-integration/OpenCellID/requirements.txt
@@ -1,4 +1,3 @@
 hvplot==0.11.2
 panel==1.6.2
 pydeck==0.9.1
-httpx==0.28.1

--- a/ngc-integration/OpenCellID/requirements.txt
+++ b/ngc-integration/OpenCellID/requirements.txt
@@ -1,3 +1,4 @@
-hvplot 
-pydeck
-panel
+hvplot==0.11.2
+panel==1.6.2
+pydeck==0.9.1
+httpx==0.28.1


### PR DESCRIPTION
## ✅ Dependency versions confirmed

After testing on **three different machines**, all libraries worked correctly with the versions listed below. We believe these are the stable and appropriate versions for the project:

```text
hvplot==0.11.2
panel==1.6.2
pydeck==0.9.1
httpx==0.28.1
